### PR TITLE
Use qs library to handle URL parameter encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ const Hapi = require('hapi');
 const server = new Hapi.Server();
 server.connection(); // no connection details for lambda
 
+const qs = require('qs');
+
 // flag so plugsin dont get reconfigured
 let loaded = false;
 
@@ -37,11 +39,9 @@ exports.handler = (event, context, callback) => {
         // lambda removes query string params from the url and places them into
         // and object in event. Hapi expects them on the url path
         let path = event.path;
-        if(event.queryStringParameters){
-            const qs = Object.keys(event.queryStringParameters).map(key => { return key + '=' + event.queryStringParameters[key]; });
-            if(qs.length > 0){
-                path += '?' + qs.join('&');
-            }
+        if (event.queryStringParameters) {
+            // Use qs library to encode URL parameters correctly
+            path += '?' + qs.stringify(event.queryStringParameters);
         }
 
         // map lambda event to hapi request

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
   "homepage": "https://github.com/carbonrobot/hapi-lambda#readme",
   "peerDependencies": {
     "hapi": ">=12.0.0"
+  },
+  "dependencies": {
+    "qs": "^6.5.1"
   }
 }


### PR DESCRIPTION
I had problem with encoded URL parameters, because current mapping solution breaks URL encoding. For example I had a timestamp:
2017-10-26T14%3A13%3A00%2B03%3A00
which decoded to
2017-10-26T14:13:00 03:00
in hapi and didn't work, because correct version contains plus (+) sign:
2017-10-26T14:13:00+03:00

I used qs library to handle urlencoding and stuff.